### PR TITLE
Add to README how to see progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ The data here is accumulated from a few sources:
 * GitHub Sponsors data for the `rfay` user (goes into the same DDEV Foundation bank account) is updated daily and automatically by the `github-sponsorships.sh` script here. (A few sponsors started way back when we didn't have the `ddev` org and have never switched over.)
 * The `invoiced-sponsorships.jsonc` and `paypal-sponsorships.jsonc` are manually maintained here when generous donors sign up for these avenues.
 
+## Tools and Scripts
+
+### Sponsorship progress for the past two months
+
+`git log --since="2 months ago" --format="%H %ad" --date=short --reverse -- data/all-sponsorships.json | while read commit date; do   value=$(git show $commit:data/all-sponsorships.json | jq '.["total_monthly_average_income"]');   echo "$date $value"; done`
+
 ## DDEV Foundation
 
 To learn more about the DDEV Foundation and its funding, see [DDEV Foundation](https://ddev.com/foundation).

--- a/data/all-sponsorships.json
+++ b/data/all-sponsorships.json
@@ -1,7 +1,7 @@
 {
   "github_ddev_sponsorships": {
-    "total_monthly_sponsorship": 3011,
-    "total_sponsors": 107,
+    "total_monthly_sponsorship": 2911,
+    "total_sponsors": 106,
     "sponsors_per_tier": {
       "$1 a month": 4,
       "$2 a month": 4,
@@ -15,7 +15,7 @@
       "$25 a month": 24,
       "$40 a month": 1,
       "$50 a month": 3,
-      "$100 a month": 8,
+      "$100 a month": 7,
       "$100 one time": 1,
       "$500 a month": 1,
       "$530 a month": 1
@@ -52,6 +52,6 @@
     }
   },
   "paypal_sponsorships": 35,
-  "total_monthly_average_income": 7874,
-  "updated_datetime": "2025-06-17T00:15:39Z"
+  "total_monthly_average_income": 7774,
+  "updated_datetime": "2025-06-17T17:03:01Z"
 }

--- a/data/github-ddev-sponsorships.jsonc
+++ b/data/github-ddev-sponsorships.jsonc
@@ -1,8 +1,8 @@
 // dynamic github sponsors information, do not edit
 {
   "github_ddev_sponsorships": {
-    "total_monthly_sponsorship": 3011,
-    "total_sponsors": 107,
+    "total_monthly_sponsorship": 2911,
+    "total_sponsors": 106,
     "sponsors_per_tier": {
       "$1 a month": 4,
       "$2 a month": 4,
@@ -16,7 +16,7 @@
       "$25 a month": 24,
       "$40 a month": 1,
       "$50 a month": 3,
-      "$100 a month": 8,
+      "$100 a month": 7,
       "$100 one time": 1,
       "$500 a month": 1,
       "$530 a month": 1


### PR DESCRIPTION
## The Issue

ChatGPT helped me sort out a way to see daily sponsorship progress.

## How This PR Solves The Issue

Added it to the README.

Note that the git log shown here was affected by the over-100-sponsors bug in 
* https://github.com/ddev/sponsorship-data/pull/3

```
$ git log --since="2 months ago" --format="%H %ad" --date=short --reverse -- data/all-sponsorships.json | while read commit date; do   value=$(git show $commit:data/all-sponsorships.json | jq '.["total_monthly_average_income"]');   echo "$date $value"; done
2025-04-18 7649
2025-04-19 7649
2025-04-20 7649
2025-04-21 7649
2025-04-22 7649
2025-04-23 7649
2025-04-24 7649
2025-04-25 7649
2025-04-26 7649
2025-04-27 7649
2025-04-28 7674
2025-04-29 7674
2025-04-30 7684
2025-05-01 7684
2025-05-02 7659
2025-05-03 7659
2025-05-04 7659
2025-05-05 7659
2025-05-06 7659
2025-05-07 7659
2025-05-08 7679
2025-05-09 7679
2025-05-10 7679
2025-05-11 7704
2025-05-12 7699
2025-05-13 7699
2025-05-14 7699
2025-05-15 7699
2025-05-16 7699
2025-05-17 7724
2025-05-18 7724
2025-05-19 7724
2025-05-20 7724
2025-05-21 7724
2025-05-22 7724
2025-05-23 7724
2025-05-24 7729
2025-05-25 7634
2025-05-26 7634
2025-05-27 7539
2025-05-28 7539
2025-05-29 7539
2025-05-30 7539
2025-05-31 7639
2025-06-01 7564
2025-06-02 7564
2025-06-03 7564
2025-06-04 7564
2025-06-05 7569
2025-06-06 7569
2025-06-07 7044
2025-06-08 7574
2025-06-09 7574
2025-06-10 7069
2025-06-10 7809
2025-06-10 7809
2025-06-11 7809
2025-06-12 7859
2025-06-13 7869
2025-06-14 7869
2025-06-15 7869
2025-06-16 7869
2025-06-17 7874
```