### PR TITLE
feat(history): make sure we have sponsorship data history, fixes #7

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -2,7 +2,7 @@ name: Deploy API Data to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [main, 20250813_sponsorship_history]
   schedule:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -2,7 +2,7 @@ name: Deploy API Data to GitHub Pages
 
 on:
   push:
-    branches: [main, 20250813_sponsorship_history]
+    branches: [main]
   schedule:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -94,6 +94,29 @@ jobs:
         run: |
           scripts/combine-sponsorships.sh
 
+      - name: Save history snapshot
+        run: |
+          mkdir -p data/history
+          cp data/all-sponsorships.json data/history/$(date +%F).json
+
+      - name: Commit and push history snapshot to history branch
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin history || true
+          git checkout -B history origin/history || git checkout --orphan history
+          git pull origin history || true
+          mkdir -p data/history
+          cp ../data/history/*.json data/history/ 2>/dev/null || true
+          git add data/history/
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: add sponsorship snapshot for $(date +%F)"
+            git push origin history
+          else
+            echo "No new history to commit"
+          fi
+          git checkout -
+
       - name: Prepare Pages deployment
         run: |
           # Maintain existing URL structure for backward compatibility

--- a/README.md
+++ b/README.md
@@ -16,9 +16,33 @@ The sponsorship data is available as a [JSON file](https://ddev.com/s/sponsorshi
 
 ## Tools and Scripts
 
+### Sponsorship History
+
+To provide sponsorship history (previously available via git history of `all-sponsorships.json`), each daily deployment now saves a snapshot of the data in `data/history/YYYY-MM-DD.json`.  
+**These snapshots are committed to the `history` branch of this repository.**  
+You can analyze sponsorship changes over time by checking out the `history` branch:
+
+```bash
+git fetch origin history
+git checkout history
+# Now data/history/ contains all snapshots
+```
+
+#### Example: Show total monthly average income over time
+
+```bash
+for f in data/history/*.json; do
+  date=$(basename $f .json)
+  value=$(jq '.["total_monthly_average_income"]' < "$f")
+  echo "$date $value"
+done | sort
+```
+
 ### Sponsorship progress for the past two months
 
 `git log --since="2 months ago" --format="%H %ad" --date=short --reverse -- data/all-sponsorships.json | while read commit date; do   value=$(git show $commit:data/all-sponsorships.json | jq '.["total_monthly_average_income"]');   echo "$date $value"; done`
+
+_Note: For recent history, use the new `data/history/` snapshots in the `history` branch as described above._
 
 ## DDEV Foundation
 
@@ -30,3 +54,4 @@ See these resources:
 
 * [Support DDEV](https://ddev.com/support-ddev/)
 * [GitHub Sponsors for DDEV](https://github.com/sponsors/ddev)
+


### PR DESCRIPTION
## The Issue

* #7 

## How This PR Solves The Issue

Add a step that pushes current date's data to a history branch

Suggested by GitHub Copilot.

## Manual Testing Instructions
Suggested by GitHub Copilot:

**Test in a Fork (Optional, for Full End-to-End)**

   - If you want to test the full workflow (including branch pushes and Pages deployment), fork the repository and follow these steps:
     - Push your PR branch to your fork.
     - Optionally, edit `.github/workflows/deploy-api.yml` in your fork to allow the workflow to run on your branch.
     - Push a commit to trigger the workflow.
     - Verify that the workflow runs, updates the `history` branch, and deploys to GitHub Pages in your fork.


Running this on main in ddev-test/sponsorship-data:
* I do see the history being created at https://github.com/ddev-test/sponsorship-data/blob/history/data/history/2025-08-13.json


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

