### PR TITLE
Fix appreciation message to announce current amount

### DIFF
--- a/data/goals.jsonc
+++ b/data/goals.jsonc
@@ -15,5 +15,5 @@
     "target_amount": 12000,
     "progress_percentage": 65.44
   },
-  "appreciation_message_template": "❤️ DDEV is thriving thanks to our amazing sponsors! We're currently at ${PROGRESS_PERCENT}% of our ${TARGET_AMOUNT}/month goal (${CURRENT_AMOUNT}/month). Your support helps us deliver the best local development experience. Help us reach ${TARGET_AMOUNT}/month by sponsoring at https://github.com/sponsors/ddev 🚀"
+  "appreciation_message_template": "❤️ DDEV is thriving thanks to our amazing sponsors! We're currently at ${PROGRESS_PERCENT}% of our ${TARGET_AMOUNT}/month goal (${CURRENT_AMOUNT}). Your support helps us deliver the best local development experience. Help us reach ${TARGET_AMOUNT}/month by sponsoring at https://github.com/sponsors/ddev 🚀"
 }


### PR DESCRIPTION
Before:
"DDEV is thriving thanks to our amazing sponsors! We're currently at 69% of our $12000/month goal ($8276/month)."

After:
"DDEV is thriving thanks to our amazing sponsors! We're currently at 69% of our $12000/month goal ($8276)."

## The Issue

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

