### PR TITLE
Fix Node 20 complaints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## The Issue

Github is complaining about node 20 in the homebrew action.

## How This PR Solves The Issue

FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'


