### PR TITLE
feat: add sponsorship progress SVG badges

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -53,6 +53,12 @@ jobs:
             exit 1
           fi
 
+      - name: Test SVG generation
+        run: |
+          scripts/generate-sponsorship-svg.sh data/all-sponsorships.json /tmp/test-badge.svg /tmp/test-badge-dark.svg
+          grep -q '<svg' /tmp/test-badge.svg && echo "Light SVG generated"
+          grep -q '<svg' /tmp/test-badge-dark.svg && echo "Dark SVG generated"
+
   deploy:
     runs-on: ubuntu-24.04
     # Only run deployment on schedule or workflow_dispatch
@@ -125,6 +131,10 @@ jobs:
           # Return to main branch
           git checkout -
 
+      - name: Generate sponsorship SVG badges
+        run: |
+          scripts/generate-sponsorship-svg.sh data/all-sponsorships.json _site/badges/sponsorship-badge.svg _site/badges/sponsorship-badge-dark.svg
+
       - name: Prepare Pages deployment
         run: |
           # Maintain existing URL structure for backward compatibility
@@ -135,48 +145,7 @@ jobs:
           mkdir -p _site/api
           cp data/all-sponsorships.json _site/api/
 
-          # Create a simple index page for the API
-          cat > _site/index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <title>DDEV Sponsorship API</title>
-            <meta charset="utf-8">
-            <style>
-              body { font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
-              pre { background: #f5f5f5; padding: 1rem; border-radius: 4px; overflow-x: auto; }
-              .endpoint { background: #e3f2fd; padding: 0.5rem; border-radius: 4px; font-family: monospace; }
-            </style>
-          </head>
-          <body>
-            <h1>DDEV Sponsorship API</h1>
-            <p>This API provides current sponsorship data for the DDEV project.</p>
-
-            <h2>Endpoints</h2>
-            <div class="endpoint">GET /data/all-sponsorships.json (original path)</div>
-            <div class="endpoint">GET /api/all-sponsorships.json (new path)</div>
-
-            <h2>Direct Links</h2>
-            <p><a href="https://ddev.com/s/sponsorship-data.json">Preferred link (ddev.com)</a></p>
-            <p><a href="data/all-sponsorships.json">Original path (backward compatible)</a></p>
-            <p><a href="api/all-sponsorships.json">New API path</a></p>
-
-            <h2>Usage</h2>
-            <pre>// Preferred: use the ddev.com short URL
-          fetch('https://ddev.com/s/sponsorship-data.json')
-            .then(response => response.json())
-            .then(data => console.log(data));
-
-          // Existing consumers - no changes needed.
-          fetch('https://ddev.github.io/sponsorship-data/data/all-sponsorships.json')
-            .then(response => response.json())
-            .then(data => console.log(data));</pre>
-
-            <h2>Repository</h2>
-            <p><a href="https://github.com/ddev/sponsorship-data">Source code and documentation</a></p>
-          </body>
-          </html>
-          EOF
+          cp src/index.html _site/index.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/scripts/combine-sponsorships.sh
+++ b/scripts/combine-sponsorships.sh
@@ -59,9 +59,12 @@ fi
 appreciation_template=$(jq -r .appreciation_message_template data/tmp/goals.json)
 progress_percent=$(printf "%.1f" "$goal_progress")
 
-# Format numbers with commas using awk
-target_formatted=$(echo "$goal_target" | awk '{printf "%'"'"'d", $1}')
-current_formatted=$(echo "$total_monthly_average_income" | awk '{printf "%'"'"'d", $1}')
+# Format numbers with commas (portable sed, no locale dependency)
+format_commas() {
+  printf '%s' "$1" | sed ':a;s/\(.*[0-9]\)\([0-9]\{3\}\)/\1,\2/;ta'
+}
+target_formatted=$(format_commas "$goal_target")
+current_formatted=$(format_commas "$total_monthly_average_income")
 
 appreciation_message=$(echo "$appreciation_template" | \
   sed "s/\${PROGRESS_PERCENT}/$progress_percent/g" | \

--- a/scripts/generate-sponsorship-svg.sh
+++ b/scripts/generate-sponsorship-svg.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+JSON_FILE="${1:-data/all-sponsorships.json}"
+LIGHT_OUTPUT="${2:-data/tmp/sponsorship-badge.svg}"
+DARK_OUTPUT="${3:-data/tmp/sponsorship-badge-dark.svg}"
+
+total_monthly=$(jq -r '.total_monthly_average_income' "$JSON_FILE")
+goal_target=$(jq -r '.current_goal.target_amount' "$JSON_FILE")
+goal_progress=$(jq -r '.current_goal.progress_percentage' "$JSON_FILE")
+
+# Format numbers with commas (portable sed, no locale dependency)
+format_commas() {
+  printf '%s' "$1" | sed ':a;s/\(.*[0-9]\)\([0-9]\{3\}\)/\1,\2/;ta'
+}
+
+total_formatted=$(format_commas "$total_monthly")
+target_formatted=$(format_commas "$goal_target")
+progress_display=$(printf "%.1f" "$goal_progress")
+
+CARD_W=760
+PAD=16
+INNER_W=$((CARD_W - 2 * PAD))
+BAR_H=8
+CARD_H=100
+
+# Logo: viewBox 261.16x199.3, scaled to 16px tall → scale=0.0803, width≈21px
+# Positioned at (PAD, 8) so it centers on the 13px title text row (baseline y=22)
+LOGO_SCALE=0.0803
+LOGO_W=21  # 261.16 * 0.0803 ≈ 21
+TITLE_X=$((PAD + LOGO_W + 5))
+
+bar_fill_w=$(awk -v w="$INNER_W" -v p="$goal_progress" 'BEGIN {
+  pct = (p > 100 ? 100 : (p < 0 ? 0 : p))
+  fill = int(w * pct / 100 + 0.5)
+  print (fill > w ? w : (fill < 0 ? 0 : fill))
+}')
+
+generate_svg() {
+  local text_primary="$1"
+  local text_secondary="$2"
+  local bar_track="$3"
+  local bar_fill_color="$4"
+  local output="$5"
+
+  mkdir -p "$(dirname "$output")"
+
+  cat > "$output" <<EOF
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 ${CARD_W} ${CARD_H}" role="img" aria-label="DDEV Sponsorship: \$${total_formatted} / month">
+  <title>DDEV Sponsorship: \$${total_formatted} / month</title>
+  <g transform="translate(${PAD}, 8) scale(${LOGO_SCALE})" fill="${text_secondary}" fill-rule="evenodd">
+    <path d="M116.77,18.59h84.55l45.32,45.33v71.47l-45.32,45.32H125.2a11.84,11.84,0,0,0-8.72-4.07,11.33,11.33,0,1,0,8.72,18.59h82.22l53.74-53.74V57.81L207.42,4.07H116.77A11.82,11.82,0,0,0,108.06,0a11.33,11.33,0,0,0,0,22.66A11.82,11.82,0,0,0,116.77,18.59Zm-8.71-12.2a4.59,4.59,0,0,1,4.64,4.54V11a4.65,4.65,0,0,1-9.29.43,3.09,3.09,0,0,1,0-.43A4.78,4.78,0,0,1,108.06,6.39Zm8.71,176.93a4.65,4.65,0,1,1-4.65,4.65h0a4.58,4.58,0,0,1,4.53-4.65Z"/>
+    <path d="M195.5,33.12H87.43v.29a10.58,10.58,0,0,0-8.14-3.49,11.34,11.34,0,1,0,9.3,18H189.4L217.59,76.1v47.35L189.4,151.64H86.85a11.84,11.84,0,0,0-8.72-4.07,11.33,11.33,0,1,0,8.72,18.59H195.21l36.61-36.6V69.73ZM79.29,36.61a4.65,4.65,0,1,1-4.64,4.66v0C74.36,38.64,76.68,36.61,79.29,36.61ZM78.42,154a4.65,4.65,0,1,1-4.65,4.65h0C73.48,156,75.81,154,78.42,154Z"/>
+    <path d="M178.65,136.55H47.34a10.75,10.75,0,0,1-7.85,3.19,11.33,11.33,0,1,1,0-22.66,11.59,11.59,0,0,1,9.3,4.94h36l-15.1-15.11H20A11.82,11.82,0,0,1,11.31,111,11.33,11.33,0,1,1,20,92.41H75.81L105.73,122H177.2L188,111.27v-23L177.2,77.57H110.67l15.11,15.11h29.34a11.84,11.84,0,0,1,8.72-4.07,11.33,11.33,0,1,1-8.72,18.59H119.68L90,77.28H50.82a11.85,11.85,0,0,1-8.71,4.07,11.33,11.33,0,1,1,8.71-18.6H183.3l19.47,19.47v35.15L183.3,136.55ZM163.84,94.71a4.65,4.65,0,1,0,4.65,4.65h0C168.78,97,166.45,94.71,163.84,94.71ZM42.4,65.08a4.65,4.65,0,1,0,4.65,4.65A4.78,4.78,0,0,0,42.4,65.08Zm-2.91,58.68a4.65,4.65,0,1,0,4.65,4.65C44.43,125.8,42.11,123.76,39.49,123.76ZM11.6,94.71a4.65,4.65,0,1,0,0,9.3,4.6,4.6,0,0,0,4.65-4.53v-.12A4.78,4.78,0,0,0,11.6,94.71Z"/>
+  </g>
+  <text x="${TITLE_X}" y="22" font-family="system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="15" font-weight="600" fill="${text_secondary}">DDEV Sponsorship</text>
+  <text x="${PAD}" y="50" font-family="system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="22" font-weight="700" fill="${text_primary}">${progress_display}% towards \$${target_formatted}/month goal</text>
+  <rect x="${PAD}" y="60" width="${INNER_W}" height="${BAR_H}" rx="4" fill="${bar_track}"/>
+  <rect x="${PAD}" y="60" width="${bar_fill_w}" height="${BAR_H}" rx="4" fill="${bar_fill_color}"/>
+  <text x="${PAD}" y="84" font-family="system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="15" fill="${text_secondary}">\$${total_formatted} / month</text>
+</svg>
+EOF
+
+  echo "Generated ${output}" >&2
+}
+
+generate_svg "#24292e" "#57606a" "#ccc" "#02a8e2" "$LIGHT_OUTPUT"
+generate_svg "#e6edf3" "#8b949e" "#ccc" "#02a8e2" "$DARK_OUTPUT"

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>DDEV Sponsorship API</title>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
+    pre { background: #f5f5f5; padding: 1rem; border-radius: 4px; overflow-x: auto; }
+    .endpoint { background: #e3f2fd; padding: 0.5rem; border-radius: 4px; font-family: monospace; }
+  </style>
+</head>
+<body>
+  <h1>DDEV Sponsorship API</h1>
+  <p>This API provides current sponsorship data for the DDEV project.</p>
+
+  <h2>Endpoints</h2>
+  <div class="endpoint">GET /data/all-sponsorships.json (original path)</div>
+  <div class="endpoint">GET /api/all-sponsorships.json (new path)</div>
+  <h2>Direct Links</h2>
+  <p><a href="https://ddev.com/s/sponsorship-data.json">Preferred link (ddev.com)</a></p>
+  <p><a href="data/all-sponsorships.json">Original path (backward compatible)</a></p>
+  <p><a href="api/all-sponsorships.json">New API path</a></p>
+
+  <h2>Usage</h2>
+  <pre>// Preferred: use the ddev.com short URL
+fetch('https://ddev.com/s/sponsorship-data.json')
+  .then(response => response.json())
+  .then(data => console.log(data));
+
+// Existing consumers: no changes needed.
+fetch('https://ddev.github.io/sponsorship-data/data/all-sponsorships.json')
+  .then(response => response.json())
+  .then(data => console.log(data));</pre>
+
+  <h2>Sponsorship Badges</h2>
+  <p><img src="badges/sponsorship-badge.svg" alt="DDEV Sponsorship badge (light mode)" style="display:block;width:100%;"></p>
+  <p><img src="badges/sponsorship-badge-dark.svg" alt="DDEV Sponsorship badge (dark mode)" style="display:block;width:100%;background:#0d1117;"></p>
+
+  <h2>Repository</h2>
+  <p><a href="https://github.com/ddev/sponsorship-data">Source code and documentation</a></p>
+</body>
+</html>

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -275,6 +275,44 @@ teardown() {
   assert_success
 }
 
+@test "generate-sponsorship-svg.sh produces valid SVG files" {
+  # Use test fixtures for predictable values
+  for file in tests/testdata/mock-*.jsonc; do
+    target="data/$(basename "$file" | sed 's/^mock-//')"
+    cp "$file" "$target"
+  done
+  run bash scripts/combine-sponsorships.sh
+  assert_success
+
+  run bash scripts/generate-sponsorship-svg.sh data/all-sponsorships.json
+  assert_success
+
+  assert_file_exists "data/tmp/sponsorship-badge.svg"
+  assert_file_exists "data/tmp/sponsorship-badge-dark.svg"
+
+  # Both files should be valid SVG
+  run grep -q '<svg' data/tmp/sponsorship-badge.svg
+  assert_success
+  run grep -q '<svg' data/tmp/sponsorship-badge-dark.svg
+  assert_success
+
+  # Light SVG should contain correct percentage and goal (1850/2000*100 = 92.5%)
+  run grep -q '92.5% towards \$2,000/month goal' data/tmp/sponsorship-badge.svg
+  assert_success
+
+  # Both SVGs should contain the formatted total amount
+  run grep -q '\$1,850' data/tmp/sponsorship-badge.svg
+  assert_success
+  run grep -q '\$1,850' data/tmp/sponsorship-badge-dark.svg
+  assert_success
+
+  # Light and dark should use different text colors
+  run grep -q '#24292e' data/tmp/sponsorship-badge.svg
+  assert_success
+  run grep -q '#e6edf3' data/tmp/sponsorship-badge-dark.svg
+  assert_success
+}
+
 @test "appreciation message is properly extracted from goals" {
   run bash scripts/combine-sponsorships.sh
   assert_success


### PR DESCRIPTION
## The Issue

GitHub's native sponsorship goal (`activeGoal.percentComplete`) causes intermittent 502 Bad Gateway errors from the GraphQL API, which broke the github.com/sponsors/ddev page for several weeks. The goal had to be removed to restore the page.

See: https://github.com/ddev/ddev.com/issues/647#issuecomment-4537321724

## How This PR Solves The Issue

Generates self-hosted SVG badge files (`sponsorship-badge.svg` and `sponsorship-badge-dark.svg`) from our own sponsorship data, without relying on GitHub's broken goal API. The badges show:
- DDEV logo + "DDEV Sponsorship" title
- Progress percentage towards the monthly goal (e.g. "83.7% towards $12,000/month goal")
- Progress bar (DDEV blue fill, neutral track)
- Current monthly total

Badges are generated daily by the deploy workflow and published to GitHub Pages under `/badges/`. Also fixes a number formatting bug in `combine-sponsorships.sh` where `awk %'d` failed to add commas in minimal CI locales.

## Manual Testing Instructions

1. Run `scripts/combine-sponsorships.sh` to generate `data/all-sponsorships.json`
2. Run `scripts/generate-sponsorship-svg.sh` — SVGs appear in `data/tmp/`
3. Open `data/tmp/sponsorship-badge.svg` and `data/tmp/sponsorship-badge-dark.svg` in a browser

<img width="300" height="39" alt="sponsorship-badge" src="https://github.com/user-attachments/assets/27a8c06d-c252-42cd-8ea1-206b83e89e38" />

<img width="300" height="39" alt="sponsorship-badge-dark" src="https://github.com/user-attachments/assets/051662c0-1aa9-4695-8b08-605fb7287aba" />

## Automated Testing Overview

Added a bats test `generate-sponsorship-svg.sh produces valid SVG files` that uses the existing mock fixtures to verify both SVG files are generated, contain the correct percentage/amount values, and use the expected light/dark color schemes.

## Release/Deployment Notes

After merge, the badges will be available at:
- https://ddev.github.io/sponsorship-data/badges/sponsorship-badge.svg
- https://ddev.github.io/sponsorship-data/badges/sponsorship-badge-dark.svg

These can be embedded in the github.com/sponsors/ddev page description to replace the removed native goal display.