### PR TITLE
feat: add use_cached_data input and use Pages base_url in index.html

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -12,6 +12,11 @@ on:
         type: boolean
         required: false
         default: false
+      use_cached_data:
+        description: 'Skip data fetch and use the latest history snapshot instead (skips history commit too)'
+        type: boolean
+        required: false
+        default: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,17 +84,28 @@ jobs:
         with:
           limit-access-to-actor: true
 
+      - name: Load latest history snapshot (cached data)
+        if: ${{ inputs.use_cached_data }}
+        run: |
+          git fetch origin history
+          LATEST=$(git ls-tree --name-only origin/history data/history/ | sort | tail -1)
+          git show "origin/history:data/history/${LATEST}" > data/all-sponsorships.json
+          echo "Using cached data from ${LATEST}"
+
       - name: Fetch GitHub sponsorship data
+        if: ${{ !inputs.use_cached_data }}
         run: |
           set -eu -o pipefail
           SPONSORED_ENTITY_NAME=ddev SPONSORED_ENTITY_TYPE=organization scripts/github-sponsorships.sh
           SPONSORED_ENTITY_NAME=rfay SPONSORED_ENTITY_TYPE=user scripts/github-sponsorships.sh
 
       - name: Generate combined data from github and static info
+        if: ${{ !inputs.use_cached_data }}
         run: |
           scripts/combine-sponsorships.sh
 
       - name: Commit and push history snapshot to history branch
+        if: ${{ !inputs.use_cached_data }}
         run: |
           # Save current data to temp location
           SNAPSHOT_DATE=$(date +%F)
@@ -120,24 +136,22 @@ jobs:
           # Return to main branch
           git checkout -
 
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v6
+
       - name: Generate sponsorship SVG badges
         run: |
           scripts/generate-sponsorship-svg.sh data/all-sponsorships.json _site/badges/sponsorship-badge.svg _site/badges/sponsorship-badge-dark.svg
 
       - name: Prepare Pages deployment
         run: |
-          # Maintain existing URL structure for backward compatibility
-          mkdir -p _site/data
+          mkdir -p _site/data _site/api
           cp data/all-sponsorships.json _site/data/
-
-          # Also provide it at /api/ for cleaner URLs
-          mkdir -p _site/api
           cp data/all-sponsorships.json _site/api/
 
           cp src/index.html _site/index.html
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
+          sed -i 's|https://ddev.github.io/sponsorship-data|${{ steps.pages.outputs.base_url }}|g' _site/index.html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy API Data to GitHub Pages](https://github.com/ddev/sponsorship-data/actions/workflows/deploy-api.yml/badge.svg)](https://ddev.github.io/sponsorship-data/)
+
 # DDEV Sponsorship Data
 
 Daily-updated sponsorship data for the DDEV project, published via GitHub Pages as a JSON API and SVG badges.


### PR DESCRIPTION
## The Issue

Two issues:
1. Testing deploy pipeline changes (index page, SVG badges) requires
   a live GitHub API fetch and a 1Password token, making quick iteration
   slow and wasteful.
2. src/index.html had hardcoded https://ddev.github.io/sponsorship-data
   URLs, which would break if the repo is forked or deployed elsewhere or we decide to use a custom domain.

## How This PR Solves The Issue

Add a `use_cached_data` boolean input (default false) to the
workflow_dispatch trigger. When enabled:
- Loads the latest JSON snapshot from the history branch instead of
  fetching live GitHub sponsorship data
- Skips combine-sponsorships.sh (data is already combined)
- Skips committing a new history snapshot

Move the Setup Pages step before Prepare Pages deployment so
steps.pages.outputs.base_url is available, then use sed to replace
the hardcoded origin in the deployed _site/index.html with the actual
Pages base URL. The source file keeps the real URL for local preview.

## Manual Testing Instructions

Trigger workflow_dispatch with `use_cached_data: true`. Verify the
deploy completes without a live API call and the deployed index.html
links point to the correct Pages URL.

## Automated Testing Overview

No test changes needed — the test job is unaffected by these inputs.

## Release/Deployment Notes

No functional change for ddev/sponsorship-data since the base URL
matches the hardcoded value. No impact on scheduled runs (input
defaults to false).