### PR TITLE
fix: fetch history correctly, for #38

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           git fetch origin history
           LATEST=$(git ls-tree --name-only origin/history data/history/ | sort | tail -1)
-          git show "origin/history:data/history/${LATEST}" > data/all-sponsorships.json
+          git show "origin/history:${LATEST}" > data/all-sponsorships.json
           echo "Using cached data from ${LATEST}"
 
       - name: Fetch GitHub sponsorship data


### PR DESCRIPTION
## The Issue

- For #38

https://github.com/ddev/sponsorship-data/actions/runs/26451231346/job/77872326605

```
Run git fetch origin history
  
From https://github.com/ddev/sponsorship-data
 * branch            history    -> FETCH_HEAD
 * [new branch]      history    -> origin/history
fatal: path 'data/history/data/history/2026-05-26.json' does not exist in 'origin/history'
Error: Process completed with exit code 128.
```

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

