### PR TITLE
docs: add integrations section with cross-links to TheDropTimes, markconroy/web-components, and blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ The combined data is published at:
 
 See the [API index page](https://ddev.github.io/sponsorship-data/) for full documentation.
 
+## Integrations
+
+| Property | Source file |
+|----------|-------------|
+| [ddev.com](https://ddev.com) | [SponsorsBanner.astro](https://github.com/ddev/ddev.com/blob/main/src/components/SponsorsBanner.astro) |
+| [addons.ddev.com](https://addons.ddev.com) | [sponsors-banner.html](https://github.com/ddev/addon-registry/blob/main/_includes/sponsors-banner.html) |
+| [docs.ddev.com](https://docs.ddev.com) | [sponsors-banner.html](https://github.com/ddev/ddev/blob/main/docs/overrides/partials/sponsors-banner.html) |
+| [thedroptimes.com](https://www.thedroptimes.com/) | |
+| [markconroy/web-components](https://web-components.mark.ie/web-components/ddev/sponsors-banner/) | [sponsors-banner.js](https://github.com/markconroy/web-components/blob/main/web-components/ddev/sponsors-banner/sponsors-banner.js) |
+
+The feed also drives sponsorship progress tips shown in the terminal at `ddev start`.
+
+See the [blog post](https://ddev.com/blog/sponsorship-data-droptimes/) for a full write-up of the project and its integrations.
+
 ## SVG Badges
 
 Two sponsorship progress badges are generated daily alongside the JSON data:
@@ -33,7 +47,6 @@ Two sponsorship progress badges are generated daily alongside the JSON data:
 |-------|-----|
 | Light mode | `https://ddev.github.io/sponsorship-data/badges/sponsorship-badge.svg` |
 | Dark mode | `https://ddev.github.io/sponsorship-data/badges/sponsorship-badge-dark.svg` |
-
 
 ## Scripts
 

--- a/src/index.html
+++ b/src/index.html
@@ -187,6 +187,17 @@
   .then(response => response.json())
   .then(data => console.log(data));</pre>
 
+  <h2>Used In</h2>
+  <table>
+    <tr><th>Property</th><th style="width:40%">Source file</th></tr>
+    <tr><td><a href="https://ddev.com">ddev.com</a></td><td><a href="https://github.com/ddev/ddev.com/blob/main/src/components/SponsorsBanner.astro">SponsorsBanner.astro</a></td></tr>
+    <tr><td><a href="https://addons.ddev.com">addons.ddev.com</a></td><td><a href="https://github.com/ddev/addon-registry/blob/main/_includes/sponsors-banner.html">sponsors-banner.html</a></td></tr>
+    <tr><td><a href="https://docs.ddev.com">docs.ddev.com</a></td><td><a href="https://github.com/ddev/ddev/blob/main/docs/overrides/partials/sponsors-banner.html">sponsors-banner.html</a></td></tr>
+    <tr><td><a href="https://www.thedroptimes.com/">thedroptimes.com</a></td><td></td></tr>
+    <tr><td><a href="https://web-components.mark.ie/web-components/ddev/sponsors-banner/">markconroy/web-components</a></td><td><a href="https://github.com/markconroy/web-components/blob/main/web-components/ddev/sponsors-banner/sponsors-banner.js">sponsors-banner.js</a></td></tr>
+  </table>
+  <p>The JSON feed also drives sponsorship progress tips shown in the terminal at <code>ddev start</code>.</p>
+
   <h2>Sponsorship Badges</h2>
   <p>Generated daily from the JSON data. Updates automatically with each deploy.</p>
 
@@ -208,8 +219,9 @@
   &lt;/picture&gt;
 &lt;/a&gt;</pre>
 
-  <h2>Repository</h2>
+  <h2>Repository &amp; Blog</h2>
   <p><a href="https://github.com/ddev/sponsorship-data">github.com/ddev/sponsorship-data</a> - source code and documentation</p>
+  <p><a href="https://ddev.com/blog/sponsorship-data-droptimes/">ddev.com/blog/sponsorship-data-droptimes</a> - blog post describing the project and its integrations</p>
 
 </main>
 


### PR DESCRIPTION
## The Issue

We have a blog https://ddev.com/blog/sponsorship-data-droptimes/

## How This PR Solves The Issue

Adds integrations section with cross-links.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

