### PR TITLE
Remove T3Planet invoice

### DIFF
--- a/data/invoiced-sponsorships.jsonc
+++ b/data/invoiced-sponsorships.jsonc
@@ -3,9 +3,9 @@
 {
   "monthly_invoiced_sponsorships": {
     // total_monthly_sponsorship must be manually maintained
-    "total_monthly_sponsorship": 3580,
+    "total_monthly_sponsorship": 3562,
     // total_sponsors must be manually maintained
-    "total_sponsors": 8,
+    "total_sponsors": 7,
     "monthly_sponsors_per_tier": {
       // cps-it, 100 Euros/month, estimate of current 
       "118": 1,
@@ -18,9 +18,7 @@
       // Tag1
       "1000": 1,
       // Upsun
-      "1162": 1,
-      // T3Planet
-      "10": 1
+      "1162": 1
     }
   },
   "annual_invoiced_sponsorships": {


### PR DESCRIPTION
T3Planet cancelled their $10/month sponsorship via PayPal. 

I stopped the harvest and QBO invoicees.

I think the total for monthly invoiced was suspect anyway, but it's updated.